### PR TITLE
Implement simple Binance WebSocket client

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 3.10)
+project(binance_ws)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+set(Boost_USE_STATIC_LIBS OFF)
+set(Boost_USE_MULTITHREADED ON)
+set(Boost_USE_STATIC_RUNTIME OFF)
+
+find_package(Boost REQUIRED COMPONENTS system thread)
+
+add_executable(binance_ws src/main.cpp)
+
+target_link_libraries(binance_ws PRIVATE Boost::system Boost::thread ssl crypto)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,0 +1,59 @@
+#include <websocketpp/config/asio_client.hpp>
+#include <websocketpp/client.hpp>
+
+#include <boost/asio/ssl/context.hpp>
+
+#include <iostream>
+#include <functional>
+
+typedef websocketpp::client<websocketpp::config::asio_tls_client> client;
+
+void on_message(client* c, websocketpp::connection_hdl, client::message_ptr msg) {
+    std::cout << msg->get_payload() << std::endl;
+}
+
+void on_open(client*, websocketpp::connection_hdl) {
+    std::cout << "Connected" << std::endl;
+}
+
+void on_fail(client*, websocketpp::connection_hdl) {
+    std::cout << "Connection Failed" << std::endl;
+}
+
+void on_close(client*, websocketpp::connection_hdl) {
+    std::cout << "Connection Closed" << std::endl;
+}
+
+int main() {
+    client c;
+
+    try {
+        c.set_access_channels(websocketpp::log::alevel::all);
+        c.set_error_channels(websocketpp::log::elevel::all);
+
+        c.init_asio();
+
+        c.set_message_handler(std::bind(&on_message, &c, std::placeholders::_1, std::placeholders::_2));
+        c.set_open_handler(std::bind(&on_open, &c, std::placeholders::_1));
+        c.set_fail_handler(std::bind(&on_fail, &c, std::placeholders::_1));
+        c.set_close_handler(std::bind(&on_close, &c, std::placeholders::_1));
+        c.set_tls_init_handler([](websocketpp::connection_hdl){
+            auto ctx = std::make_shared<boost::asio::ssl::context>(boost::asio::ssl::context::tlsv12_client);
+            ctx->set_default_verify_paths();
+            ctx->set_verify_mode(boost::asio::ssl::verify_none);
+            return ctx;
+        });
+
+        websocketpp::lib::error_code ec;
+        auto con = c.get_connection("wss://stream.binance.com:9443/ws/btcusdt@trade", ec);
+        if (ec) {
+            std::cout << "Connection init error: " << ec.message() << std::endl;
+            return 1;
+        }
+
+        c.connect(con);
+        c.run();
+    } catch(const std::exception& e) {
+        std::cerr << "Exception: " << e.what() << std::endl;
+    }
+}


### PR DESCRIPTION
## Summary
- set up basic CMake project using Boost
- implement a small WebSocket++ client that connects to Binance trade feed

## Testing
- `cmake .. && make -j$(nproc)`

------
https://chatgpt.com/codex/tasks/task_e_68428f7a7bb4832cb9a1ff187559a227