### PR TITLE
Enable OpenSSL in get_mids example

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,3 +21,5 @@ target_link_libraries(main PRIVATE
 # Example using header-only cpp-httplib
 add_executable(get_mids src/get_mids.cpp)
 target_include_directories(get_mids PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include)
+target_compile_definitions(get_mids PRIVATE CPPHTTPLIB_OPENSSL_SUPPORT)
+target_link_libraries(get_mids PRIVATE OpenSSL::SSL OpenSSL::Crypto)

--- a/src/get_mids.cpp
+++ b/src/get_mids.cpp
@@ -1,3 +1,4 @@
+#define CPPHTTPLIB_OPENSSL_SUPPORT
 #include "httplib.h"
 #include <iostream>
 


### PR DESCRIPTION
## Summary
- enable OpenSSL in `get_mids.cpp` by defining `CPPHTTPLIB_OPENSSL_SUPPORT`
- link OpenSSL in `get_mids` target via CMake

## Testing
- `./build.sh`
- `./build/get_mids` *(fails: Request failed)*

------
https://chatgpt.com/codex/tasks/task_e_684bc9d7fd0c832cbcf7bbdc8783e495